### PR TITLE
Fix spontaneous playback issue

### DIFF
--- a/backgroundFetch.js
+++ b/backgroundFetch.js
@@ -1,15 +1,33 @@
 import * as BackgroundFetch from 'expo-background-fetch';
 import * as TaskManager from 'expo-task-manager';
+import TrackPlayer, { State } from 'react-native-track-player';
 import { customLog, customError } from './customLogger';
+import StorageManager from './StorageManager';
 
 const BACKGROUND_FETCH_TASK = 'background-fetch';
 
 TaskManager.defineTask(BACKGROUND_FETCH_TASK, async () => {
   try {
     customLog('Background fetch started');
-    // Your background fetch logic here
-      // No track playing, try to start the next one
-    await TrackPlayer.play();
+    
+    // Only resume playback if the user was actually playing when they left the app
+    const wasPlayingWhenLeft = await StorageManager.getItem('wasPlayingWhenLeft');
+    
+    if (wasPlayingWhenLeft === 'true') {
+      const currentState = await TrackPlayer.getState();
+      customLog('Current TrackPlayer state:', currentState);
+      
+      // Only resume if the player is paused or ready, not if it's already playing
+      if (currentState === State.Paused || currentState === State.Ready) {
+        customLog('Resuming playback from background fetch');
+        await TrackPlayer.play();
+      } else {
+        customLog('TrackPlayer already in playing state, no action needed');
+      }
+    } else {
+      customLog('User was not playing when they left the app, not resuming playback');
+    }
+    
     customLog('Background fetch completed');
     return BackgroundFetch.BackgroundFetchResult.NewData;
   } catch (error) {
@@ -21,7 +39,7 @@ TaskManager.defineTask(BACKGROUND_FETCH_TASK, async () => {
 export const registerBackgroundFetch = async () => {
   try {
     await BackgroundFetch.registerTaskAsync(BACKGROUND_FETCH_TASK, {
-      minimumInterval: 60, // 1 minute
+      minimumInterval: 15 * 60, // 15 minutes instead of 1 minute
       stopOnTerminate: false,
       startOnBoot: true,
     });


### PR DESCRIPTION
Spontaneous playback was resolved by introducing user intent tracking and making auto-playback conditional.

*   A `wasPlayingWhenLeft` flag, stored via `StorageManager`, now tracks if the user was actively playing music when the app was backgrounded or terminated.
*   In `backgroundFetch.js`:
    *   Playback is now only resumed if `wasPlayingWhenLeft` is `true`.
    *   The `minimumInterval` for background fetches was increased from 1 minute to 15 minutes.
*   In `service.js`:
    *   `Event.RemotePlay`, `Event.RemotePause`, and `Event.RemoteStop` handlers now update the `wasPlayingWhenLeft` flag based on user action.
    *   Automatic track loading and playback in `Event.PlaybackQueueEnded` and `State.Stopped` handlers now only proceed if `wasPlayingWhenLeft` is `true`.
*   In `useAudioPlayer.js`:
    *   `loadRandomFile`, `loadFile`, and `togglePlayback` functions update `wasPlayingWhenLeft` to reflect manual play/pause actions.
    *   The `saveLastSongState` function updates `wasPlayingWhenLeft` based on the player's state when the app transitions to the background.
    *   The `startPlaybackWatchdog` now only attempts to resume playback if `wasPlayingWhenLeft` is `true`, and its check interval was increased from 5 to 10 seconds.

These changes ensure playback only resumes when explicitly intended by the user, while preserving background and lock screen controls.